### PR TITLE
Update site to take buzzcorner and notes from data

### DIFF
--- a/data/buzzcorner/sample.yml
+++ b/data/buzzcorner/sample.yml
@@ -1,0 +1,4 @@
+links:
+  - title: devkami repo
+    url: https://github.com/devxkami
+    description: this is a test link

--- a/data/notes/sample.yml
+++ b/data/notes/sample.yml
@@ -1,0 +1,4 @@
+links:
+  - title: devkami repo
+    url: https://github.com/devxkami
+    description: this is a test link

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -12,6 +12,25 @@
           </div>
 
           <h3 id="show-notes">Show notes</h3>
+          {{ if .Params.notes }}
+          <dl>
+          {{ range (index $.Site.Data.notes .Params.notes).links }}
+            <dt>{{ .title }}</dt>
+            <dd>{{ .description }}</dd>
+            <dd><a href="{{ .url }}">link</a></dd>
+          {{ end }}
+          </dl>
+          {{ end }}
+        {{ end }}
+        {{ if .Params.buzzcorner }}
+        <h3 id="buzzcorner">Buzzcorner</h3>
+        <dl>
+        {{ range (index $.Site.Data.buzzcorner .Params.buzzcorner).links }}
+          <dt>{{ .title }}</dt>
+          <dd>{{ .description }}</dd>
+          <dd><a href="{{ .url }}">link</a></dd>
+        {{ end }}
+        </dl>
         {{ end }}
 
         {{ .Content }}


### PR DESCRIPTION
This is to add feature to load show notes and buzzcorner into devkami site

![Screenshot from 2020-09-22 22-21-27](https://user-images.githubusercontent.com/80779/93895154-1918ea00-fd22-11ea-99cc-d8bd6cb1c5b2.png)
 
To use this add 2 variable, `buzzcorner` and `notes` in the post. For example

```
---
title: "DevKami 101 - Trial buzzcorner"
date: 2020-09-22
youtubeid: "bft5vvqIjcY"
buzzcorner: "sept_22"
notes: "sept22"
---

Data can be a list of objects. the following example is in yaml. Put in `data/buzzcorner` directory if used in `buzzcorner`, `data/notes` directory if in `notes`

```
links:
  - title: devkami repo
    url: https://github.com/devxkami
    description: this is a test link
```

```
